### PR TITLE
Working propotype

### DIFF
--- a/README.org
+++ b/README.org
@@ -44,7 +44,8 @@ and then to install this package,
   (use-package org-noter-media
     :straight '(org-noter-media :type git
                                 :host github
-                                :repo "auroranil/org-noter-media"))
+                                :repo "auroranil/org-noter-media"
+                                :fork "c1-g/org-noter-media"))
 #+end_src
 
 * DONE Integration with mpv player 

--- a/README.org
+++ b/README.org
@@ -1,34 +1,79 @@
 * org-noter-media
- - Synchronise notes with video/audio files using mpv player
- - Repository stems from this Github issue
-   - [[https://github.com/weirdNox/org-noter/issues/127][{Enhancement} Expand scope so that it can take notes from video and audio, bo...]]
- - *Currently a work in progress*
-   - Not ready for use
-   - If you want to contribute, you are more than welcome to.
-* TODO Integration with mpv player 
-  - Planning to use JSON IPC 
-    - [[https://github.com/kljohann/mpv.el/wiki][Home · kljohann/mpv.el Wiki · GitHub]]
-    - [[https://github.com/rndusr/subed][GitHub - rndusr/subed: Subtitle editor for Emacs]] 
-* TODO Operations
-** Inserting [0/1]
-  - [ ] =org-noter-insert-note=
-** Synchronising [0/1]
-   - [ ] =org-noter-sync-current-note=
-** Media player specific [0/1]
-   - [ ] =org-noter-media-toggle-play=
+- Synchronise notes with video/audio files using mpv player
+- Repository stems from this Github issue
+  - [[https://github.com/weirdNox/org-noter/issues/127][{Enhancement} Expand scope so that it can take notes from video and audio, bo...]]
+- *Currently a work in progress*
+  - +Not ready for use+
+  - If you want to contribute, you are more than welcome to.
+* Caveat & Installation
+** Incompatible with upstream org-noter
+The way org-noter originally works is that it will call ~find-file~ on the value of =NOTER_DOCUMENT=, resulting
+in a new buffer then, get the ~major-mode~ of this new buffer to call the appropriate functions for the mode.
 
-* TODO Plan
-  1. [ ] Creating new =org-noter= session with media file in =NOTER_DOCUMENT=
-         property should open =mpv= playing that media file from beginning
-  2. [ ] Specifying =NOTER_PAGE= property in root org heading should open
-         =mpv= playing that media file at that specified time
-  3. [ ] Communicate to =org-noter-media= its timestamp as video is playing,
-         so that it knows when to sync automatically
-  4. [ ] Specifying =NOTER_PAGE= property in non-root org heading should
-         show that heading and hide others (when =org-noter-hide-others= is
-         set to true) when playing video reaches that section
-  5. [ ] Implement =org-noter-sync-current-note=
-  6. [ ] Implement =org-noter-insert-note=
-  7. [ ] Implement =org-noter-media-toggle-play=
-  8. [ ] Find out a way to customise org-noter properties so that its
-         terminology aligns with media files
+For example, if your =NOTER_DOCUMENT= is a path to a pdf file, org-noter will call ~find-file~ resulting in a new buffer
+with in the ~major-mode~ called ~pdf-view-mode~. Org-noter then passes the ~pdf-view-mode~ to various function to handle the mode as expected.
+
+This breaks down, however, when our =NOTER_DOCUMENT= is a binary file (mp3, mp4, etc.) that Emacs has no mode to handle yet.
+
+If only we can customize the way org-noter find its =NOTER_DOCUMENT= and try to remove ~major-mode~ for the equation.
+
+** Link-as-doc
+This modified version of org-noter can handle =[[links]]= as its source document.
+
+See https://github.com/c1-g/org-noter-plus-djvu/tree/link-as-doc.
+
+To install it, with [[https://github.com/radian-software/straight.el.git][straight.el]] and [[https://github.com/jwiegley/use-package][use-package]],
+
+#+begin_src emacs-lisp
+  (use-package org-noter
+    :straight '(org-noter :type git
+                          :host nil
+                          :repo "https://github.com/c1-g/org-noter-plus-djvu.git"
+                          :branch "link-as-doc"
+                          :files ("other/*.el" "*.el" "modules/*.el"))
+    :config
+    (use-package org-noter-nov :ensure nil)
+    (use-package org-noter-djvu :ensure nil)
+    (use-package org-noter-pdf :ensure nil))
+#+end_src
+and then to install this package,
+
+#+begin_src emacs-lisp
+  (use-package org-noter-media
+    :straight '(org-noter-media :type git
+                                :host github
+                                :repo "auroranil/org-noter-media"))
+#+end_src
+
+* DONE Integration with mpv player 
+- Planning to use JSON IPC 
+  - [[https://github.com/kljohann/mpv.el/wiki][Home · kljohann/mpv.el Wiki · GitHub]]
+  - [[https://github.com/rndusr/subed][GitHub - rndusr/subed: Subtitle editor for Emacs]] 
+* DONE Operations
+** Inserting [1/1]
+- [X] =org-noter-insert-note=
+** Synchronising [1/1]
+- [X] =org-noter-sync-current-note=
+** Media player specific [0/1]
+- [-] =org-noter-media-toggle-play=
+
+* DONE Plan
+1. [X] Creating new =org-noter= session with media file in =NOTER_DOCUMENT=
+   property should open =mpv= playing that media file from beginning
+2. [X] Specifying =NOTER_PAGE= property in root org heading should open
+   =mpv= playing that media file at that specified time
+3. [X] Communicate to =org-noter-media= its timestamp as video is playing,
+   so that it knows when to sync automatically
+4. [X] Specifying =NOTER_PAGE= property in non-root org heading should
+   show that heading and hide others (when =org-noter-hide-others= is
+   set to true) when playing video reaches that section
+5. [X] Implement =org-noter-sync-current-note=
+6. [X] Implement =org-noter-insert-note=
+7. [-] Implement =org-noter-media-toggle-play=
+   This feature is already available in ~org-media-note~. Try ~M-x org-media-note-hydra/body <SPC>~
+8. [-] Find out a way to customise org-noter properties so that its
+   terminology aligns with media files
+
+   For me, the default =NOTER_DOCUMENT= is already satisfactory. I tend to think of "document" in a more abstract sense, that is, an object that gives information; so it is not only a paper but it can be a video, audio, speech, etc.
+
+   But for a more neutral term, maybe =NOTER_SOURCE=?

--- a/README.org
+++ b/README.org
@@ -24,6 +24,8 @@ See https://github.com/c1-g/org-noter-plus-djvu/tree/link-as-doc.
 
 To install it, with [[https://github.com/radian-software/straight.el.git][straight.el]] and [[https://github.com/jwiegley/use-package][use-package]],
 
+put these in your config file.
+
 #+begin_src emacs-lisp
   (use-package org-noter
     :straight '(org-noter :type git

--- a/README.org
+++ b/README.org
@@ -74,7 +74,7 @@ and then to install this package,
 6. [X] Implement =org-noter-insert-note=
 7. [-] Implement =org-noter-media-toggle-play=
    
-   This feature is already available in ~org-media-note~. Try ~M-x org-media-note-hydra/body <SPC>~
+   This feature is already available in ~mpv.el~. Try ~M-x mpv-pause~
 8. [-] Find out a way to customise org-noter properties so that its
    terminology aligns with media files
 

--- a/README.org
+++ b/README.org
@@ -70,6 +70,7 @@ and then to install this package,
 5. [X] Implement =org-noter-sync-current-note=
 6. [X] Implement =org-noter-insert-note=
 7. [-] Implement =org-noter-media-toggle-play=
+   
    This feature is already available in ~org-media-note~. Try ~M-x org-media-note-hydra/body <SPC>~
 8. [-] Find out a way to customise org-noter properties so that its
    terminology aligns with media files

--- a/README.org
+++ b/README.org
@@ -29,8 +29,9 @@ put these in your config file.
 #+begin_src emacs-lisp
   (use-package org-noter
     :straight '(org-noter :type git
-                          :host nil
-                          :repo "https://github.com/c1-g/org-noter-plus-djvu.git"
+                          :host github
+                          :repo "weirdNox/org-noter"
+                          :fork "c1-g/org-noter-plus-djvu"
                           :branch "link-as-doc"
                           :files ("other/*.el" "*.el" "modules/*.el"))
     :config

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -48,7 +48,10 @@
 
 (defun org-noter-media-open-document (doc-prop)
   (when (org-noter-media-check-doc doc-prop)
-    (mpv-start (org-noter-media-check-doc doc-prop))
+    (mpv-start
+     (when (org-entry-get nil org-noter-property-note-location)
+       (concat "--start=" (number-to-string (org-noter--parse-location-property (org-entry-get nil org-noter-property-note-location)))))
+     (org-noter-media-check-doc doc-prop))
     (current-buffer)))
 
 (add-to-list 'org-noter-open-document-functions #'org-noter-media-open-document)

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -1,0 +1,164 @@
+;edia.el --- Module for integrating org-media-note with org-noter  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022  c1-g
+
+;; Author: c1-g <char1iegordon@protonmail.com>
+;; Keywords: multimedia
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; TODO: Documentation
+
+;;; Code:
+(require 'org-media-note)
+(require 'org-noter)
+(require 'cl-lib)
+
+(defcustom org-noter-media-extensions
+  ;; From EMMS package; emms-player-base-format-list
+  '("ogg" "mp3" "wav" "mpg" "mpeg" "wmv" "wma" "mov" "avi" "divx"
+    "ogm" "ogv" "asf" "mkv" "rm" "rmvb" "mp4" "flac" "vob" "m4a" "ape"
+    "flv" "webm" "aif" "opus")
+  "All file extensions that mpv can play.")
+
+(defvar-local org-noter-media-video-timer nil
+  "")
+
+(defun org-noter-media-get-media-name ()
+  (mpv-get-property "path"))
+
+(defun org-noter-media--parse-location (s)
+  (when (and (string-match org-link-bracket-re s)
+             (string-match-p (regexp-opt '("video" "audio" "videocite" "audiocite"))
+                             (org-element-property :type (org-noter-parse-link s))))
+    (let* ((s (match-string 1 s))
+           (splitted (split-string s "#"))
+           (file-path-or-url (nth 0 splitted))
+           (timestamps (split-string (nth 1 splitted)
+                                     "-"))
+           (time-a (org-timer-hms-to-secs (nth 0 timestamps)))
+           (time-b (if (= (length timestamps) 2)
+                       (org-timer-hms-to-secs (nth 1 timestamps)))))
+      time-a)))
+
+(add-to-list 'org-noter--parse-location-property-hook #'org-noter-media--parse-location)
+
+(defun org-noter-media--relative-position-to-view (location view)
+  (when (eq (aref view 0) 'timed)
+    (setq view (aref view 1))
+    (setq location (if (stringp location)
+                        (string-to-number location)
+                      location))
+    (cond ((< location view) 'before)
+          ((= location view) 'inside)
+          (t 'after))))
+
+(add-to-list 'org-noter--relative-position-to-view-hook #'org-noter-media--relative-position-to-view)
+
+(defun org-noter-media--pretty-print-location (location)
+  (org-noter--with-valid-session
+   (when (and (stringp (org-noter--session-doc-mode session))
+              (string-match-p (regexp-opt '("video" "audio" "videocite" "audiocite"))
+                              (org-noter--session-doc-mode session)))
+     (let* ((file-path (mpv-get-property "path"))
+            (link-type (if (org-media-note-ref-cite-p)
+                           (concat (org-media-note--current-media-type)
+                                   "cite")
+                         (org-media-note--current-media-type)))
+            (filename (mpv-get-property "media-title"))
+            (duration (org-media-note--get-duration-timestamp))
+            (timestamp (org-timer-secs-to-hms location)))
+       (if (org-media-note--ab-loop-p)
+           ;; ab-loop link
+           (let ((time-a (org-media-note--seconds-to-timestamp (mpv-get-property "ab-loop-a")))
+                 (time-b (org-media-note--seconds-to-timestamp (mpv-get-property "ab-loop-b"))))
+             (format "[[%s:%s#%s-%s][%s]]"
+                     link-type
+                     (org-media-note--link-base-file file-path)
+                     time-a
+                     time-b
+                     (org-media-note--link-formatter org-media-note-ab-loop-link-format
+                                                     `(("filename" . ,filename)
+                                                       ("duration" . ,duration)
+                                                       ("ab-loop-a" . ,time-a)
+                                                       ("ab-loop-b" . ,time-b)
+                                                       ("file-path" . ,file-path)))))
+         ;; timestamp link
+         (format "[[%s:%s#%s][%s]]"
+                 link-type
+                 (org-media-note--link-base-file file-path)
+                 timestamp
+                 (org-media-note--link-formatter org-media-note-timestamp-link-format
+                                                 `(("filename" . ,filename)
+                                                   ("duration" . ,duration)
+                                                   ("timestamp" . ,timestamp)
+                                                   ("file-path" . ,file-path)))))))))
+
+
+(add-to-list 'org-noter--pretty-print-location-hook #'org-noter-media--pretty-print-location)
+
+(defun org-noter-media-approx-location (mode &optional precise-info _force-new-ref)
+  (when (or (and (stringp mode)
+                 (string-match-p (regexp-opt '("video" "audio" "videocite" "audiocite")) mode)))
+    (string-to-number (org-media-note--timestamp-to-seconds (org-media-note--get-current-timestamp)))))
+
+(add-hook 'org-noter--doc-approx-location-hook #'org-noter-media-approx-location)
+
+(defun org-noter-media--get-precise-info (major-mode)
+  (when (and (stringp mode)
+             (string-match-p (regexp-opt '("video" "audio" "videocite" "audiocite")) mode))
+    (string-to-number (org-media-note--timestamp-to-seconds (org-media-note--get-current-timestamp)))))
+
+(defun org-noter-media--get-current-view (major-mode)
+  (when (and (stringp major-mode)
+             (string-match-p (regexp-opt '("video" "audio" "videocite" "audiocite")) major-mode))
+    (vector 'timed (string-to-number (org-media-note--timestamp-to-seconds (org-media-note--get-current-timestamp))))))
+
+(add-to-list 'org-noter--get-current-view-hook #'org-noter-media--get-current-view)
+
+(defun org-noter-media-setup-handler (major-mode)
+  (when (and (stringp major-mode)
+             (string-match-p (regexp-opt '("video" "audio" "videocite" "audiocite")) major-mode))
+    (run-with-idle-timer
+     1 t
+     (lambda ()
+       (org-noter--with-valid-session
+        (org-noter--doc-location-change-handler))))
+    t))
+
+(add-to-list 'org-noter-set-up-document-handler #'org-noter-media-setup-handler)
+
+(defun org-noter-media--get-selected-text (mode)
+  (when (and (stringp mode)
+             (string-match-p (regexp-opt '("video" "audio" "videocite" "audiocite")) mode))
+    (condition-case nil
+        (mpv-get-property "sub-text")
+      (error nil))))
+
+(defun org-noter-media-goto-location (mode location)
+  (when (and (stringp mode)
+             (string-match-p (regexp-opt '("video" "audio" "videocite" "audiocite")) mode))
+    (let* ((splitted (split-string link "#"))
+           (file-path-or-url (nth 0 splitted))
+           (timestamps (split-string (nth 1 splitted)
+                                     "-"))
+           (time-a (org-media-note--timestamp-to-seconds (nth 0 timestamps)))
+           (time-b (if (= (length timestamps) 2)
+                       (org-media-note--timestamp-to-seconds (nth 1 timestamps)))))
+      (org-media-note--seek-position-in-current-media-file time-a time-b))))
+
+(provide 'org-noter-media)
+;;; org-noter-media.el ends here

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -144,10 +144,8 @@
 (defun org-noter-media-setup-handler (major-mode)
   (when (org-noter-media-check-doc major-mode)
     (run-with-idle-timer
-     1 t
-     (lambda ()
-       (org-noter--with-valid-session
-        (org-noter--doc-location-change-handler))))
+     1 t (lambda () (org-noter--with-valid-session
+                     (org-noter--doc-location-change-handler))))
     t))
 
 (add-to-list 'org-noter-set-up-document-hook #'org-noter-media-setup-handler)

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -1,4 +1,4 @@
-;edia.el --- Module for integrating org-media-note with org-noter  -*- lexical-binding: t; -*-
+;;; org-noter-media.el --- Module for integrating org-media-note with org-noter  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2022  c1-g
 

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -164,5 +164,7 @@
   (when (org-noter-media-check-doc mode)
     (org-media-note--seek-position-in-current-media-file location)))
 
+(add-to-list 'org-noter--doc-goto-location-hook 'org-noter-media-goto-location)
+
 (provide 'org-noter-media)
 ;;; org-noter-media.el ends here

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -89,7 +89,7 @@
 (defun org-noter-media--pretty-print-location (location)
   (org-noter--with-valid-session
    (when (org-noter-media-check-doc (org-noter--session-property-text session))
-     (let* ((file-path (mpv-get-property "path"))
+     (let* ((file-path (org-noter--session-property-text session))
             (link-type (if (org-media-note-ref-cite-p)
                            (concat (org-media-note--current-media-type)
                                    "cite")
@@ -219,6 +219,17 @@
        output-data))))
 
 (add-to-list 'org-noter-create-skeleton-functions #'org-noter-media-create-skeleton)
+
+(defun org-noter-media--mpv-property-ad (property)
+  (org-noter--with-valid-session
+   (save-excursion
+     (pcase property
+       ("path" (org-noter--session-property-text session))
+       ("media-title" (progn (while (org-up-heading-safe))
+                             (or (org-entry-get nil "title")
+                                 (nth 4 (org-heading-components)))))))))
+
+(advice-add 'mpv-get-property :before-until #'org-noter-media--mpv-property-ad)
 
 (provide 'org-noter-media)
 ;;; org-noter-media.el ends here

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -58,12 +58,8 @@
     (let* ((s (match-string 1 s))
            (splitted (split-string s "#"))
            (file-path-or-url (nth 0 splitted))
-           (timestamps (split-string (nth 1 splitted)
-                                     "-"))
-           (time-a (org-timer-hms-to-secs (nth 0 timestamps)))
-           (time-b (if (= (length timestamps) 2)
-                       (org-timer-hms-to-secs (nth 1 timestamps)))))
-      time-a)))
+           (timestamps (split-string (nth 1 splitted) "-")))
+      (org-timer-hms-to-secs (nth 0 timestamps)))))
 
 (add-to-list 'org-noter--parse-location-property-hook #'org-noter-media--parse-location)
 

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -75,6 +75,13 @@
 
 (add-to-list 'org-noter--relative-position-to-view-hook #'org-noter-media--relative-position-to-view)
 
+(defun org-noter-media--convert-to-location-cons (location)
+  (if (and location (consp location))
+      location
+    (cons location 0)))
+
+(add-to-list 'org-noter--convert-to-location-cons-hook #'org-noter-media--convert-to-location-cons)
+
 (defun org-noter-media--pretty-print-location (location)
   (org-noter--with-valid-session
    (when (org-noter-media-check-doc (org-noter--session-property-text session)) 

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -154,8 +154,8 @@
 (defun org-noter-media-setup-handler (major-mode)
   (when (org-noter-media-check-doc major-mode)
     (run-with-idle-timer
-     1 t (lambda () (org-noter--with-valid-session
-                     (org-noter--doc-location-change-handler))))
+     1.5 t (lambda () (org-noter--with-valid-session
+                       (org-noter--doc-location-change-handler))))
     t))
 
 (add-to-list 'org-noter-set-up-document-hook #'org-noter-media-setup-handler)

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -118,8 +118,8 @@
 (add-hook 'org-noter--doc-approx-location-hook #'org-noter-media-approx-location)
 
 (defun org-noter-media--get-precise-info (major-mode)
-  (when (and (stringp mode)
-             (string-match-p (regexp-opt '("video" "audio" "videocite" "audiocite")) mode))
+  (when (and (stringp major-mode)
+             (string-match-p (regexp-opt '("video" "audio" "videocite" "audiocite")) major-mode))
     (string-to-number (org-media-note--timestamp-to-seconds (org-media-note--get-current-timestamp)))))
 
 (defun org-noter-media--get-current-view (major-mode)

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -122,6 +122,8 @@
              (string-match-p (regexp-opt '("video" "audio" "videocite" "audiocite")) major-mode))
     (string-to-number (org-media-note--timestamp-to-seconds (org-media-note--get-current-timestamp)))))
 
+(add-to-list 'org-noter--get-precise-info-hook #'org-noter-media--get-precise-info)
+
 (defun org-noter-media--get-current-view (major-mode)
   (when (and (stringp major-mode)
              (string-match-p (regexp-opt '("video" "audio" "videocite" "audiocite")) major-mode))

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -141,12 +141,14 @@
 
 (add-to-list 'org-noter-set-up-document-handler #'org-noter-media-setup-handler)
 
-(defun org-noter-media--get-selected-text (mode)
+(defun org-noter-media--get-sub-text (mode)
   (when (and (stringp mode)
              (string-match-p (regexp-opt '("video" "audio" "videocite" "audiocite")) mode))
     (condition-case nil
         (mpv-get-property "sub-text")
       (error nil))))
+
+(add-to-list 'org-noter-get-selected-text-hook #'org-noter-media--get-sub-text)
 
 (defun org-noter-media-goto-location (mode location)
   (when (and (stringp mode)

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -34,8 +34,6 @@
     "flv" "webm" "aif" "opus")
   "All file extensions that mpv can play.")
 
-(defvar-local org-noter-media-video-timer nil
-  "")
 (defun org-noter-media-check-doc (document-property)
   (when (stringp document-property)
     (cond ((and (string-match org-link-bracket-re document-property)
@@ -46,8 +44,6 @@
                (string-match-p "youtu\\.?be" document-property))
            document-property))))
 
-(defun org-noter-media-get-media-name ()
-  (mpv-get-property "path"))
 (add-to-list 'org-noter--check-location-property-hook 'org-noter-media-check-doc)
 
 (defun org-noter-media--parse-location (s)

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -150,7 +150,7 @@
         (org-noter--doc-location-change-handler))))
     t))
 
-(add-to-list 'org-noter-set-up-document-handler #'org-noter-media-setup-handler)
+(add-to-list 'org-noter-set-up-document-hook #'org-noter-media-setup-handler)
 
 (defun org-noter-media--get-sub-text (mode)
   (when (org-noter-media-check-doc mode)

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -49,9 +49,10 @@
 (defun org-noter-media-open-document (doc-prop)
   (when (org-noter-media-check-doc doc-prop)
     (mpv-start
-     (when (org-entry-get nil org-noter-property-note-location)
-       (concat "--start=" (number-to-string (org-noter--parse-location-property (org-entry-get nil org-noter-property-note-location)))))
-     (org-noter-media-check-doc doc-prop))
+     (or (and (org-entry-get nil org-noter-property-note-location)
+              (concat "--start=" (number-to-string (org-noter--parse-location-property (org-entry-get nil org-noter-property-note-location)))))
+         "")
+     doc-prop)
     (current-buffer)))
 
 (add-to-list 'org-noter-open-document-functions #'org-noter-media-open-document)

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -46,6 +46,13 @@
 
 (add-to-list 'org-noter--check-location-property-hook 'org-noter-media-check-doc)
 
+(defun org-noter-media-open-document (doc-prop)
+  (when (org-noter-media-check-doc doc-prop)
+    (mpv-start (org-noter-media-check-doc doc-prop))
+    (current-buffer)))
+
+(add-to-list 'org-noter-open-document-functions #'org-noter-media-open-document)
+
 (defun org-noter-media--parse-location (s)
   (when (org-noter-media-check-doc s)
     (let* ((s (match-string 1 s))

--- a/org-noter-media.el
+++ b/org-noter-media.el
@@ -84,7 +84,7 @@
 
 (defun org-noter-media--pretty-print-location (location)
   (org-noter--with-valid-session
-   (when (org-noter-media-check-doc (org-noter--session-property-text session)) 
+   (when (org-noter-media-check-doc (org-noter--session-property-text session))
      (let* ((file-path (mpv-get-property "path"))
             (link-type (if (org-media-note-ref-cite-p)
                            (concat (org-media-note--current-media-type)
@@ -92,7 +92,12 @@
                          (org-media-note--current-media-type)))
             (filename (mpv-get-property "media-title"))
             (duration (org-media-note--get-duration-timestamp))
-            (timestamp (org-timer-secs-to-hms location)))
+            (splitted-timestamp (split-string (number-to-string location) "\\(\\.\\|,\\)"))
+            (timestamp (org-timer-secs-to-hms (string-to-number (nth 0 splitted-timestamp))))
+            (fff (if (= (length splitted-timestamp) 2)
+                     (format ".%s" (nth 1 splitted-timestamp))
+                   "")))
+
        (if (org-media-note--ab-loop-p)
            ;; ab-loop link
            (let ((time-a (org-media-note--seconds-to-timestamp (mpv-get-property "ab-loop-a")))
@@ -109,10 +114,11 @@
                                                        ("ab-loop-b" . ,time-b)
                                                        ("file-path" . ,file-path)))))
          ;; timestamp link
-         (format "[[%s:%s#%s][%s]]"
+         (format "[[%s:%s#%s%s][%s]]"
                  link-type
                  (org-media-note--link-base-file file-path)
                  timestamp
+                 fff
                  (org-media-note--link-formatter org-media-note-timestamp-link-format
                                                  `(("filename" . ,filename)
                                                    ("duration" . ,duration)


### PR DESCRIPTION
For this package to work, it requires changes to the way org-noter find its document. So it can only work with a branch called `link-as-doc` in my fork of org-noter which you can find [here](https://github.com/c1-g/org-noter-plus-djvu/tree/link-as-doc). 

For installation guide see [this](https://github.com/c1-g/org-noter-media/blob/main/README.org)